### PR TITLE
Magemojo 1.3.7 & fix php 8.1

### DIFF
--- a/Console/Command/CronCommand.php
+++ b/Console/Command/CronCommand.php
@@ -1,25 +1,33 @@
 <?php
+
 namespace MageMojo\Cron\Console\Command;
 
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputOption;
+use Magento\Cron\Observer\ProcessCronQueueObserver;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
+use Magento\Framework\Shell\ComplexParameter;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManager;
-use Magento\Framework\Console\Cli;
-use Magento\Cron\Observer\ProcessCronQueueObserver;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for executing cron jobs
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CronCommand extends Command
 {
     /**
      * Name of input option
      */
-    const INPUT_KEY_GROUP = 'group';
+    public const INPUT_KEY_GROUP = 'group';
 
     /**
      * Object manager factory
@@ -29,18 +37,31 @@ class CronCommand extends Command
     private $objectManagerFactory;
 
     /**
+     * Application deployment configuration
+     *
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
      * Constructor
      *
      * @param ObjectManagerFactory $objectManagerFactory
+     * @param DeploymentConfig|null $deploymentConfig Application deployment configuration
      */
-    public function __construct(ObjectManagerFactory $objectManagerFactory)
-    {
+    public function __construct(
+        ObjectManagerFactory $objectManagerFactory,
+        DeploymentConfig $deploymentConfig = null
+    ) {
         $this->objectManagerFactory = $objectManagerFactory;
+        $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(
+            DeploymentConfig::class
+        );
         parent::__construct();
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {
@@ -65,11 +86,25 @@ class CronCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * Runs cron jobs if cron is not disabled in Magento configurations
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     * @throws FileSystemException
+     * @throws RuntimeException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->deploymentConfig->get('cron/enabled', 1)) {
+            $output->writeln('<info>' . 'Cron is disabled. Jobs were not run.' . '</info>');
+
+            return Cli::RETURN_SUCCESS;
+        }
+        // phpcs:ignore Magento2.Security.Superglobal
+
         // Force set the scope for
         $omParams = $_SERVER;
         $omParams[StoreManager::PARAM_RUN_CODE] = 'admin';
@@ -77,11 +112,26 @@ class CronCommand extends Command
 
         $objectManager = $this->objectManagerFactory->create($omParams);
 
+        $params[self::INPUT_KEY_GROUP] = $input->getOption(self::INPUT_KEY_GROUP);
         $params[ProcessCronQueueObserver::STANDALONE_PROCESS_STARTED] = '0';
+        $bootstrap = $input->getOption(Cli::INPUT_KEY_BOOTSTRAP);
+        if ($bootstrap) {
+            $bootstrapProcessor = new ComplexParameter(Cli::INPUT_KEY_BOOTSTRAP);
+            $bootstrapOptionValues = $bootstrapProcessor->getFromString(
+                '--' . Cli::INPUT_KEY_BOOTSTRAP . '=' . $bootstrap
+            );
+            $bootstrapOptionValue = $bootstrapOptionValues[ProcessCronQueueObserver::STANDALONE_PROCESS_STARTED];
+            if ($bootstrapOptionValue) {
+                $params[ProcessCronQueueObserver::STANDALONE_PROCESS_STARTED] = $bootstrapOptionValue;
+            }
+        }
 
         /** @var \MageMojo\Cron\Model\Schedule $application */
         $application = $objectManager->create(\MageMojo\Cron\Model\Schedule::class, ['parameters' => $params]);
-
         $application->launch();
+
+        $output->writeln('<info>' . 'Ran jobs by schedule.' . '</info>');
+
+        return Cli::RETURN_SUCCESS;
     }
 }

--- a/Controller/Adminhtml/Settings/Index.php
+++ b/Controller/Adminhtml/Settings/Index.php
@@ -66,6 +66,17 @@ class Index extends \Magento\Backend\App\Action
 	        $fail = true;
 	        $this->messageManager->addError('Consumers Timeout must be numeric');
 	      }
+          if (is_numeric($this->getRequest()->getParam('exporters_timeout'))) {
+            $this->resource->setConfigValue('magemojo/cron/exporters_timeout','default',0,$this->getRequest()->getParam('exporters_timeout'));
+          } else {
+            $fail = true;
+            $this->messageManager->addError('Exporters Timeout must be numeric');
+          }
+	      if ($this->getRequest()->getParam('consumersgovernor')) {
+	        $this->resource->setConfigValue('magemojo/cron/consumersgovernor','default',0,1);
+	      } else {
+	        $this->resource->setConfigValue('magemojo/cron/consumersgovernor','default',0,0);
+	      }
 	      if (!$fail) {
 	        $this->messageManager->addSuccess('Cron Configuration Saved');
 	      }

--- a/Model/Config/Data.php
+++ b/Model/Config/Data.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MageMojo\Cron\Model\Config;
+
+use Magento\Cron\Model\Config\Reader\Xml as XmlReader;
+use Magento\Cron\Model\Config\Reader\Db as DbReader;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\Config\CacheInterface;
+
+/**
+ * Provides cron configuration
+ */
+class Data extends \Magento\Cron\Model\Config\Data
+{
+    protected $_dbReader;
+    protected $_reader;
+
+    /**
+     * Constructor
+     *
+     * @param XmlReader $reader
+     * @param CacheInterface $cache
+     * @param DbReader $dbReader
+     */
+    public function __construct(
+        XmlReader $reader,
+        CacheInterface $cache,
+        DbReader $dbReader
+    ) {
+        $this->_dbReader = $dbReader;
+        $this->_reader = $reader;
+        parent::__construct($reader, $cache,$dbReader);
+        $this->merge($dbReader->get());
+    }
+
+    /**
+     * Refresh config and get jobs
+     *
+     * @return array
+     */
+    public function getJobs()
+    {
+        $this->refreshConfig();
+        return $this->get();
+    }
+
+    /**
+     * Refresh data for configuration
+     *
+     * @return void
+     */
+    public function refreshConfig()
+    {
+        $this->_data = $this->_reader->read();
+        $this->merge($this->_dbReader->get());
+    }
+}

--- a/Model/ResourceModel/Schedule.php
+++ b/Model/ResourceModel/Schedule.php
@@ -14,10 +14,14 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     /**
      * Get a value from core_config_data
      *
+     * @param $path
+     * @param $scope
+     * @param $scopeid
      * @return string
      */
-    public function getConfigValue($path,$scope,$scopeid) {
-      #making our own function for this because it doesnt't work anyplace consistantly
+    public function getConfigValue($path,$scope,$scopeid)
+    {
+      #making our own function for this because it doesn't work anyplace consistently
       $connection = $this->getConnection();
       $select = $connection->select()
         ->from($this->getTable('core_config_data'),['value'])
@@ -34,7 +38,7 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
      * @return void
      */
     public function setConfigValue($path,$scope,$scopeid,$value) {
-      #making our own function for this because it doesnt't work anyplace consistantly
+      #making our own function for this because it doesn't work anyplace consistently
       $connection = $this->getConnection();
       $updatedata = array('value' => $value);
       $connection->update($this->getTable('core_config_data'),$updatedata,['path = ?' => $path,'scope_id = ?' => $scopeid,'scope = ?' => $scope]);
@@ -43,7 +47,7 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     /**
      * Get all magemojo/cron values from core_config_data
      *
-     * @return void
+     * @return array
      */
     public function getSettings() {
       $connection = $this->getConnection();
@@ -57,7 +61,7 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     /**
      * Get the max date scheduled from cron_schedule
      *
-     * @return timestamp
+     * @return string timestamp
      */
     public function getLastJobTime() {
       $connection = $this->getConnection();
@@ -70,7 +74,10 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     /**
      * Create rows in cron_schedule for a job_code
      *
-     * @return void
+     * @param $job
+     * @param $created
+     * @param $schedule
+     * @return array
      */
     public function saveSchedule($job, $created, $schedule) {
       $connection = $this->getConnection();
@@ -115,10 +122,16 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     public function getPendingJobs() {
       $connection = $this->getConnection();
       $select = $connection->select()
-            ->from($this->getTable('cron_schedule'),['max(schedule_id) as schedule_id','job_code','count(*) as job_count'])
+            ->from($this->getTable('cron_schedule'), [
+                'max(schedule_id) as schedule_id',
+                'job_code',
+                'count(*) as job_count',
+                'min(scheduled_at) as scheduled_at'
+            ])
             ->where('status = ?', 'pending')
             ->where('scheduled_at < ?', date('Y-m-d H:i:s',time()))
-            ->group('job_code');
+            ->group('job_code')
+            ->order(new \Zend_Db_Expr("scheduled_at ASC"));
       $result = $connection->fetchAll($select);
       return $result;
     }
@@ -183,21 +196,30 @@ class Schedule extends \Magento\Cron\Model\ResourceModel\Schedule
     }
 
     /**
-     * Set jobs to error if runtime service was termininated for running jobs
+     * Set jobs to error if runtime service was terminated for running jobs
+     * @param string|int|null $scheduleId
      *
      * @return void
      */
-    public function resetSchedule() {
+    public function resetSchedule($scheduleId = null) {
       $connection = $this->getConnection();
       $message = 'Parent Cron Process Terminated Abnormally';
-      $connection->update($this->getTable('cron_schedule'),['status' => 'error', 'messages' => $message],['status = ?' => 'running']);
-      $connection->update($this->getTable('cron_schedule'),['status' => 'missed'],['status = ?' => 'pending', 'scheduled_at < ?' => date('Y-m-d H:i:s',time())]);
+
+      /* if a scheduleId was provided, update it as having terminating abnormally; otherwise, update all running jobs*/
+      $selectRunningJobs = ['status = ?' => 'running'];
+      if (!empty($scheduleId)) {
+        $selectRunningJobs['schedule_id'] = $scheduleId;
+      }
+      $connection->update($this->getTable('cron_schedule'),['status' => 'error', 'messages' => $message],$selectRunningJobs);
+
+      $selectPendingJobs = ['status = ?' => 'pending', 'scheduled_at < ?' => date('Y-m-d H:i:s',time())];
+      $connection->update($this->getTable('cron_schedule'),['status' => 'missed'],$selectPendingJobs);
     }
 
     /**
      * Trim cron_schedule table
      *
-     * @return void
+     * @return array
      */
     public function cleanSchedule($days) {
       $connection = $this->getConnection();

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -3,12 +3,25 @@ namespace MageMojo\Cron\Model;
 
 use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaList;
-use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Filesystem\directoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\MessageQueue\ConnectionTypeResolver;
 use Magento\Framework\MessageQueue\Consumer\Config\ConsumerConfigItemInterface;
+use Magento\Framework\MessageQueue\QueueRepository;
 use Magento\Framework\ObjectManager\ConfigLoaderInterface;
+
+use function extension_loaded;
+use function newrelic_end_transaction;
+use function ini_get;
+use function newrelic_start_transaction;
+use function newrelic_name_transaction;
+use function newrelic_background_job;
+use function newrelic_end_of_transaction;
+use function getmypid;
+use function strpos;
+use function is_int;
+use function file_exists;
 
 /**
  * Class Schedule
@@ -19,19 +32,19 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
 {
     const VAR_FOLDER_PATH = BP . '/'. directoryList::VAR_DIR;
     const CRON_FOLDER_PATH = '/cron/schedule';
+    const CRON_SERVICE_PIDFILE = 'cron.pid';
 
-    private $simultaniousJobs;
+    private $simultaneousJobs;
     private $phpproc;
     private $maxload;
     private $history;
-    private $scheduleoverrides;
     private $config;
     private $cronenabled;
-    private $runningPids;
     private $cronconfig;
     private $lastJobTime;
     private $pendingjobs;
     private $loadavgtest;
+    private $governor;
     private $directoryList;
     private $resource;
 
@@ -55,6 +68,16 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
     private $basedir;
     private $consumerConfig;
     private $deploymentConfig;
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var \Magento\Framework\MessageQueue\QueueRepository
+     */
+    private $queueRepository;
 
     /**
      * @var \Magento\Framework\Event\ManagerInterface
@@ -92,8 +115,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      * Schedule constructor.
      *
      * @param \Magento\Cron\Model\Config $cronconfig
-     * @param directoryList $directoryList
-     * @param ResourceModel\Schedule $resource
+     * @param \Magento\Framework\App\Filesystem\directoryList $directoryList
+     * @param \MageMojo\Cron\Model\ResourceModel\Schedule $resource
      * @param \Magento\Framework\App\Console\Request $request
      * @param \Magento\Framework\App\Console\Response $response
      * @param \Magento\Framework\App\MaintenanceMode $maintenance
@@ -101,10 +124,14 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      * @param \Magento\Framework\Filesystem\Driver\File $file
      * @param \Magento\Framework\MessageQueue\Consumer\ConfigInterface $consumerConfig
      * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\MessageQueue\QueueRepository $queueRepository
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param \Magento\Framework\Process\PhpExecutableFinderFactory $phpExecutableFinderFactory
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @param \Magento\Framework\App\AreaList|null $areaList
-     * @param ConnectionTypeResolver|null $mqConnectionTypeResolver
+     * @param \Magento\Framework\MessageQueue\ConnectionTypeResolver|null $mqConnectionTypeResolver
      * @param array $data
      */
     public function __construct(
@@ -118,6 +145,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
         \Magento\Framework\Filesystem\Driver\File $file,
         \Magento\Framework\MessageQueue\Consumer\ConfigInterface $consumerConfig,
         \Magento\Framework\App\DeploymentConfig $deploymentConfig,
+        ScopeConfigInterface $scopeConfig,
+        QueueRepository $queueRepository,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\Process\PhpExecutableFinderFactory $phpExecutableFinderFactory,
@@ -136,6 +165,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
         $this->file = $file;
         $this->consumerConfig = $consumerConfig;
         $this->deploymentConfig = $deploymentConfig;
+        $this->scopeConfig = $scopeConfig;
+        $this->queueRepository = $queueRepository;
         $this->eventManager = $eventManager;
         $this->objectManager = $objectManager;
         $this->phpExecutableFinder = $phpExecutableFinderFactory->create();
@@ -154,17 +185,12 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      */
     public function getConfig() {
       $jobs = array();
-      $scheduleoverrides = array();
       foreach($this->cronconfig->getJobs() as $groupname=>$group) {
-        $override =  $this->resource->getConfigValue('system/cron/'.$groupname.'/schedule_generate_every',0,'default');
-        if ($override) {
-          $scheduleoverrides[$groupname] = '*/'.$override;
-        }
         foreach($group as $name=>$job) {
           if (!is_array($job)) continue;
           if (!isset($job["schedule"])) {
             if (isset($job["config_path"])) {
-              $schedule =  $this->resource->getConfigValue($job["config_path"],0,'default');
+              $schedule =  $this->scopeConfig->getValue($job["config_path"]);
               if ($schedule) {
                 $job["schedule"] = $schedule;
               }
@@ -179,8 +205,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
           $jobs[$name] = $job;
         }
       }
-      $this->scheduleoverrides = $scheduleoverrides;
       $this->config = $jobs;
+        return $jobs;
     }
 
     /**
@@ -192,15 +218,27 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       #Keep the service alive indefinitely
       ini_set('max_execution_time', 0);
 
+      #Set transaction name for New Relic, if installed
+      if (extension_loaded ('newrelic')) {
+        newrelic_name_transaction ('magemojo_cron');
+        newrelic_background_job();
+      }
+
       $this->getConfig();
       $this->getRuntimeParameters();
+
+      if (!$this->cronenabled) {
+        $this->printWarn('Cron is disabled');
+        return;
+      }
+
       $this->cleanupProcesses();
       $this->lastJobTime = $this->resource->getLastJobTime();
       if ($this->lastJobTime < time() - 360) {
         $this->lastJobTime = time();
       }
-      $pid = getmypid();
-      $this->setPid('cron.pid',$pid);
+      $pid = $this->getMyPid();
+      $this->setPid(self::CRON_SERVICE_PIDFILE,$pid);
       $this->pendingjobs = $this->resource->getAllPendingJobs();
       $this->loadavgtest = true;
       if (!is_readable('/proc/cpuinfo')) {
@@ -210,14 +248,22 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
     }
 
     /**
+     * @return false|int
+     */
+    public function getMyPid(){
+        $pid = getmypid();
+
+        return $pid;
+    }
+
+    /**
      * Check file in var/cron for running process pid or schedule output
      *
-     * @return string
+     * @return string|false|null
      */
     public function checkPid($pidfile) {
       if (file_exists(self::VAR_FOLDER_PATH.'/cron/'.$pidfile)){
-        $scheduleid = file_get_contents(self::VAR_FOLDER_PATH.'/cron/'.$pidfile);
-        return $scheduleid;
+        return file_get_contents(self::VAR_FOLDER_PATH.'/cron/'.$pidfile);
       }
       return false;
     }
@@ -228,7 +274,6 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      * @return void
      */
     public function setPid($file,$scheduleid) {
-      #print 'file='.$file;
       file_put_contents(self::VAR_FOLDER_PATH.'/cron/'.$file,$scheduleid);
     }
 
@@ -254,10 +299,16 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       $filelist = scandir(self::VAR_FOLDER_PATH.'/cron/');
 
       foreach ($filelist as $file) {
-        if ($file != 'cron.pid') {
+        /* ignore current dir, parent dir, and the cron service file itself. */
+        $isCronPidFile = is_int(strpos($file,"cron"));
+        if ($isCronPidFile && $file != self::CRON_SERVICE_PIDFILE) {
           $pid = str_replace('cron.','',$file);
           if (is_numeric($pid)) {
-            $pids[$pid] = file_get_contents(self::VAR_FOLDER_PATH.'/cron/'.$file);
+            /* add to an array indexed by the hostname */
+            $filePath = self::VAR_FOLDER_PATH.'/cron/'.$file;
+            if (file_exists($filePath)) {
+              $pids[$pid] = file_get_contents(self::VAR_FOLDER_PATH . '/cron/' . $file);
+            }
           }
         }
       }
@@ -267,9 +318,11 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
     /**
      * Check if a pid is still running
      *
+     * @param $pid
      * @return bool
      */
-    public function checkProcess($pid) {
+    public function checkProcess($pid)
+    {
       if (file_exists( "/proc/$pid" )){
         return true;
       }
@@ -295,17 +348,23 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      * @return void
      */
     public function cleanupProcesses() {
-      $running = array();
-      $pids =  $this->getRunningPids();
-      foreach ($pids as $pid=>$scheduleid) {
-        if (!$this->checkProcess($pid)) {
-          $this->unsetPid('cron.'.$pid);
-          $this->resource->resetSchedule();
-        } else {
-          array_push($running,$pid);
+      $this->printInfo('Running Process Cleanup');
+
+      $this->checkRunningJobs();
+      if ($this->governor) {
+        $this->consumersCleanup();
+      }
+    }
+
+    public function consumersCleanup() {
+      $this->printInfo('Running Consumers Cleanup');
+      while ($pgrep = exec('pgrep -x strace')) {
+        $pids = explode("\n",$pgrep);
+        foreach ($pids as $pid) {
+          $childpid = $this->getChildProcess($pid);
+          $this->consumersTerminate($pid);
         }
       }
-      $this->runningPids = $running;
     }
 
     /**
@@ -314,19 +373,23 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      * @return void
      */
     public function getRuntimeParameters() {
-      $this->simultaniousJobs = $this->resource->getConfigValue('magemojo/cron/jobs',0,'default');
+      $this->simultaneousJobs = $this->resource->getConfigValue('magemojo/cron/jobs',0,'default');
       $this->phpproc = $this->resource->getConfigValue('magemojo/cron/phpproc',0,'default') ?: $this->phpExecutableFinder->find() ?: 'php';
       $this->maxload = $this->resource->getConfigValue('magemojo/cron/maxload',0,'default');
       $this->history = $this->resource->getConfigValue('magemojo/cron/history',0,'default');
       $this->cronenabled = $this->resource->getConfigValue('magemojo/cron/enabled',0,'default') && $this->deploymentConfig->get('cron/enabled', 1);
+      $this->governor = $this->resource->getConfigValue('magemojo/cron/consumersgovernor',0,'default');
     }
 
     /**
      * Checks an individual cron expression for validity
      *
+     * @param $expr
+     * @param $value
      * @return bool
      */
-    public function checkCronExpression($expr,$value) {
+    public function checkCronExpression($expr,$value)
+    {
       foreach (explode(',',$expr) as $e) {
         if (($e == '*') or ($e == $value)) {
           return true;
@@ -360,10 +423,6 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
         if (isset($job["schedule"])) {
           $schedule = array();
           $expr = explode(' ',$job["schedule"]);
-          #check if the generate schedule override is set and change the minute expression accordingly
-          if (isset($this->scheduleoverrides[$job["group"]])) {
-            $expr[0] = $this->scheduleoverrides[$job["group"]];
-          }
           $buildtime = (floor($from/60)*60);
           while ($buildtime < $to) {
             $buildtime = $buildtime + 60;
@@ -414,9 +473,12 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       $this->basedir = $this->directoryList->getRoot();
       $this->checkCronFolderExistence();
       $this->printInfo('Healthchecking Cron Service');
-      $pid = $this->checkPid('cron.pid');
-      if (!$this->checkProcess($pid) or (!$pid)) {
-        $this->initialize();
+      $pid = $this->checkPid(self::CRON_SERVICE_PIDFILE);
+      /* continue only if we lack a cron service pid or if the current host was running the service, but the process was killed */
+      $noPid = empty($pid);
+      $processRunning = $this->checkProcess($pid);
+      $this->initialize();
+      if ($noPid || !($processRunning)) {
         if ($this->cronenabled == 0) {
           exit;
         } else {
@@ -493,7 +555,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       $code = str_replace('<<method>>',$jobconfig["method"],$code);
       $code = str_replace('<<instance>>',$jobconfig["instance"],$code);
       $code = str_replace('<<scheduleid>>',$scheduleid,$code);
-      $code = str_replace('<<group_id>>', $jobconfig['group'], $code);
+      $code = str_replace('<<group_id>>', $jobconfig['group'] ?? 'default', $code);
       $code = str_replace('<<name>>',$jobconfig["name"]??'',$code);
       return $code;
     }
@@ -514,11 +576,13 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
           return false;
         }
       }
-      if ($this->isMaintenanceEnabled()) {
+
+      $maint = $this->isMaintenanceEnabled();
+      if ($maint) {
         $this->printWarn("Crons suspended due to maintenance mode being enabled");
         return false;
       }
-      if ($jobcount > $this->simultaniousJobs) {
+      if ($jobcount > $this->simultaneousJobs) {
         return false;
       }
       return true;
@@ -544,7 +608,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
      *
      * @return collection
      */
-    function getPendingJobs() {
+    function getPendingJobs()
+    {
       $jobs = array();
       foreach ($this->pendingjobs as $job) {
         if (($job["status"] == 'pending') and ($job["scheduled_at"] < date('Y-m-d H:i:s',time()))) {
@@ -557,6 +622,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
         }
       }
 
+      return $jobs;
     }
 
     /**
@@ -567,6 +633,19 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
     function setJobStatus($scheduleid,$status,$output) {
       $this->pendingjobs[$scheduleid]["status"] = $status;
       $this->resource->setJobStatus($scheduleid,$status,$output);
+    }
+
+    /**
+     * Set a job by schedule id
+     *
+     * @return array
+     */
+    function getJob($scheduleid) {
+      if (isset($this->pendingjobs[$scheduleid])) {
+        return $this->pendingjobs[$scheduleid];
+      }
+
+      return NULL;
     }
 
     /**
@@ -581,14 +660,17 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       #Force UTC
       date_default_timezone_set('UTC');
 
-      #Set transaction name for New Relic, if installed
-      if (extension_loaded ('newrelic')) {
-        newrelic_name_transaction ('magemojo_cron_service');
-      }
-
       $this->printInfo("Starting Cron Service");
       #Loop until killed or heat death of the universe
       while (true) {
+        if (extension_loaded ('newrelic')) {
+          /* send the transaction data up to newrelic. Start fresh for this service loop. */
+          newrelic_end_transaction();
+
+          newrelic_start_transaction(ini_get('newrelic.appname'), ini_get('newrelic.license'));
+          newrelic_name_transaction ('magemojo_cron_service');
+          newrelic_background_job();
+        }
         $this->getRuntimeParameters();
         if ($this->cronenabled == 0 || $this->isMaintenanceEnabled()) {
           $this->printWarn("Stopped Cron Service by maintenance is enabled");
@@ -604,33 +686,23 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
         }
 
         #Checking running jobs
-        $running = $this->getRunningPids();
-        $jobcount = 0;
-        foreach ($running as $pid=>$scheduleid) {
-          if (!$this->checkProcess($pid)) {
-            $output = $this->getJobOutput($scheduleid);
-            #If output had "error" in the text, assume it errored
-            if (strpos(strtolower($output),'error') > 0) {
-              $this->setJobStatus($scheduleid,'error',$output);
-            } else {
-              $this->setJobStatus($scheduleid,'success',$output);
-            }
-            $this->unsetPid('cron.'.$pid);
-            $this->unsetPid('schedule.'.$scheduleid);
-          } else {
-            $jobcount++;
-          }
-        }
+        $jobcount = $this->checkRunningJobs();
 
         #Get pending jobs
         $pending = $this->resource->getPendingJobs();
         $maxConsumerMessages = intval($this->deploymentConfig->get('cron_consumers_runner/max_messages', 10000));
         $consumersTimeout =  intval($this->resource->getConfigValue('magemojo/cron/consumers_timeout',0,'default'));
+        $exportersTimeout =  intval($this->resource->getConfigValue('magemojo/cron/exporters_timeout',0,'default'));
         if (!$consumersTimeout) {
           $consumersTimeout = 0;
         }
+
+        if (!$exportersTimeout) {
+          $exportersTimeout = 0;
+        }
+
         while (count($pending) && $this->canRunJobs($jobcount, $pending)) {
-          $job = array_pop($pending);
+          $job = array_shift($pending);
           $runcheck = $this->resource->getJobByStatus($job["job_code"],'running');
           if (count($runcheck) == 0) {
             $jobconfig = $this->getJobConfig($job["job_code"]);
@@ -640,15 +712,25 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
             #if this is a consumers job use a different runtime cmd
             if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
               $consumerName = str_replace("mm_consumer_","",$jobconfig["name"]);
+              if (!$this->canExecuteConsumer($consumerName)) {
+                continue;
+              }
               $runtime = "bin/magento queue:consumers:start " . escapeshellarg($consumerName);
               if ($maxConsumerMessages) {
                 $runtime .= ' --max-messages=' . $maxConsumerMessages;
               }
               $runtime = escapeshellcmd($this->phpproc)." ".$runtime;
-              if ($consumersTimeout != 0) {
+              if ($consumerName === 'exportProcessor') {
+                if ($exportersTimeout != 0) {
+                  $runtime = "timeout -s 9 " . $exportersTimeout . " " . $runtime;
+                }
+              } elseif ($consumersTimeout != 0) {
                 $runtime = "timeout -s 9 ".$consumersTimeout." ".$runtime;
               }
               $cmd = $runtime;
+              if ($this->governor) {
+                $cmd = 'strace '.$cmd;
+              }
             } else {
               $runtime = $this->prepareStub($jobconfig,$stub,$job["schedule_id"]);
               if ($runtime) {
@@ -658,7 +740,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
                   continue;
               }
             }
-            $exec = sprintf("%s; %s &> %s & echo $!",
+            $exec = sprintf("%s; %s > %s 2>&1 & echo $!",
               'cd ' . escapeshellarg($this->basedir),
               $cmd,
               escapeshellarg($this->basedir . "/var/cron/schedule." . $job["schedule_id"])
@@ -667,7 +749,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
 
             #If the output is not numeric then it errored due to syntax
             if (is_numeric($pid)) {
-              $this->setPid('cron.'.$pid,$job["schedule_id"]);
+              $this->setPid($this->getPidFileName($pid), $job["schedule_id"]);
               $this->setJobStatus($job["schedule_id"],'running',NULL);
               $jobcount++;
             } else {
@@ -685,6 +767,10 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
 
         #Sanity check processes and look for escaped inmates
         $this->asylum();
+        if (extension_loaded ('newrelic')) {
+          /* stop timing the current transaction, but continue instrumenting it */
+          newrelic_end_of_transaction();
+        }
 
         #Take a break
         sleep(5);
@@ -746,23 +832,86 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
 
 
     /**
+     * Check for consumers processes in infinate loop states and terminate them
+     *
+     * @return void
+     */
+    public function consumersGovenor($pid,$scheduleid) {
+      $tail = $this->getJobOutput($scheduleid,True);
+      #Check for repeating strings indicating an infinately looping processes
+      $checks = array(
+        $this->consumersCheck($tail,'SELECT `queue_message`.`top"',1),
+        $this->consumersCheck($tail,'rt_sigsuspend([]',0)
+      );
+      if (in_array(True,$checks)) {
+        $this->consumersTerminate($pid);
+      }
+    }
+
+    /**
+     * Check for consumers processes in infinite loop states and terminate them
+     *
+     * @param $log
+     * @param $loopstring
+     * @param $instances
+     * @return bool
+     */
+    public function consumersCheck($log,$loopstring,$instances): bool
+    {
+      if (substr_count($log,$loopstring) > $instances) {
+        return True;
+      }
+      return False;
+    }
+
+    /**
+     * Terminate a consumers process
+     *
+     * @return void
+     */
+    public function consumersTerminate($pid) {
+      $childpid = $this->getChildProcess($pid);
+      if ($this->checkProcess($pid)) {
+        exec("kill -9 $childpid");
+      }
+    }
+
+    /**
+     * Gets the child process of a running cron
+     *
+     * @return int
+     */
+    public function getChildProcess($pid) {
+      $childpid = exec('pgrep -P '.$pid);
+      if ($childpid) {
+        #Recursive call to get the final php process
+        return $this->getChildProcess($childpid);
+      } else {
+        return $pid;
+      }
+    }
+
+
+    /**
      * Check for processes that have gone insane and handle the errors
      *
      * @return void
      */
     public function asylum() {
-      #Look for running pids and compare to jobs listed as running in cron_schedule
+      $this->checkRunningJobs();
+
+      //Look for anything still "running" and compare to jobs listed as running in cron_schedule
       $crons = $this->getRunningPids();
       $jobs = $this->resource->getJobsByStatus('running');
       $running = array();
       $schedules = array();
       $pids = array();
       foreach ($crons as $pid=>$scheduleid) {
-        array_push($running,$scheduleid);
+        $running[] = $scheduleid;
         $pids[$scheduleid] = $pid;
       }
       foreach ($jobs as $job) {
-        array_push($schedules,$job["schedule_id"]);
+         $schedules[] = $job["schedule_id"];
       }
       $diff = array_diff($schedules,$running);
       foreach ($diff as $scheduleid) {
@@ -777,12 +926,12 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
 
         $pid = $pids["scheduleid"];
         $this->printInfo("Found orphaned pid file for schedule_id ".$scheduleid);
-        $this->unsetPid('cron.'.$pid);
+        $this->unsetPid($this->getPidFileName($pid));
       }
 
       #Detect a coup and acquiesce
-      $pid = getmypid();
-      $execpid = $this->checkPid('cron.pid');
+      $pid = $this->getMyPid();
+      $execpid = $this->checkPid(self::CRON_SERVICE_PIDFILE);
       if ($pid != $execpid){
         exit;
       }
@@ -813,10 +962,14 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       $this->basedir = $this->directoryList->getRoot();
       $this->checkCronFolderExistence();
       $this->initialize();
+      /* gets a list of all schedule ids in the cron table */
       $scheduleids = $this->resource->cleanSchedule($this->history);
+      /* gets a list of all cron schedule output files */
       $fileids = $this->getScheduleOutputIds();
+      /* get a list of all schedule output files that are no longer in the cron schedule file */
       $diff = array_diff($fileids,$scheduleids);
       foreach ($diff as $id) {
+        /* remove the old cron schedule output files */
         $this->unsetPid('schedule.'.$id);
       }
     }
@@ -855,6 +1008,8 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
     /**
      *  Checks if a consumers job can be run
      *
+     * @param ConsumerConfigItemInterface $consumerConfig
+     * @param array $allowedConsumers
      * @return bool
      */
     private function canConsumerBeRun(ConsumerConfigItemInterface $consumerConfig, array $allowedConsumers = []): bool {
@@ -866,11 +1021,90 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       $connectionName = $consumerConfig->getConnection();
       try {
         $this->mqConnectionTypeResolver->getConnectionType($connectionName);
-      } catch (\LogicException $e) {
+      } catch (LogicException $e) {
         $this->printInfo(sprintf('Consumer "%s" skipped as required connection "%s" is not configured. %s',$consumerName,$connectionName,$e->getMessage()));
         return false;
       }
       return true;
     }
 
+    /**
+     * @param string $pid
+     *
+     * @return string
+     */
+    public function getPidFileName($pid)
+    {
+        $prefix = 'cron.';
+
+        return $prefix . $pid;
+    }
+
+    private function canExecuteConsumer($consumerName)
+    {
+      $config = $this->consumerConfig->getConsumer($consumerName);
+      $connectionName = $config->getConnection();
+      $queueName = $config->getQueue();
+      try {
+        return $this->checkMessagesAvailable(
+          $connectionName,
+          $queueName
+        );
+      } catch (\LogicException $e) {
+        return false;
+      }
+    }
+
+    private function checkMessagesAvailable($connectionName, $queueName): bool  {
+      $queue = $this->queueRepository->get($connectionName, $queueName);
+      $message = $queue->dequeue();
+      if ($message) {
+        $queue->reject($message);
+        return true;
+      }
+      return false;
+    }
+
+
+    /**
+     * @return int number of currently running jobs
+     */
+    public function checkRunningJobs(){
+      $running = $this->getRunningPids();
+      $jobcount = 0;
+      foreach ($running as $pid=>$scheduleid) {
+
+        if ($this->governor) {
+          $job = $this->getJob($scheduleid);
+          if (isset($job["job_code"])) {
+            $jobconfig = $this->getJobConfig($job["job_code"]);
+            if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
+              #run the consumers governor
+              $this->consumersGovenor($pid, $scheduleid);
+            }
+          }
+        }
+
+        if (!$this->checkProcess($pid)) {
+          #IF this is a consumers job it was run under strace and we do not want this output
+          if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
+            $output = '';
+          } else {
+            $output = $this->getJobOutput($scheduleid);
+          }
+
+          #If output had "error" in the text, assume it errored
+          if (strpos(strtolower($output),'error') > 0) {
+            $this->setJobStatus($scheduleid,'error',$output);
+          } else {
+            $this->setJobStatus($scheduleid,'success',$output);
+          }
+          $this->unsetPid($this->getPidFileName($pid));
+          $this->unsetPid('schedule.'.$scheduleid);
+        } else {
+          $jobcount++;
+        }
+      }
+      return $jobcount;
+    }
 }

--- a/Model/Schedule.php
+++ b/Model/Schedule.php
@@ -422,7 +422,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       foreach($this->config as $job) {
         if (isset($job["schedule"])) {
           $schedule = array();
-          $expr = explode(' ',$job["schedule"]);
+          $expr = explode(' ',(string)$job["schedule"]);
           $buildtime = (floor($from/60)*60);
           while ($buildtime < $to) {
             $buildtime = $buildtime + 60;
@@ -552,9 +552,9 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
       }
       $code = trim($stub);
       $code = str_replace('<<basedir>>',$this->basedir,$code);
-      $code = str_replace('<<method>>',$jobconfig["method"],$code);
-      $code = str_replace('<<instance>>',$jobconfig["instance"],$code);
-      $code = str_replace('<<scheduleid>>',$scheduleid,$code);
+      $code = str_replace('<<method>>',(string)$jobconfig["method"],$code);
+      $code = str_replace('<<instance>>',(string)$jobconfig["instance"],$code);
+      $code = str_replace('<<scheduleid>>',(string)$scheduleid,$code);
       $code = str_replace('<<group_id>>', $jobconfig['group'] ?? 'default', $code);
       $code = str_replace('<<name>>',$jobconfig["name"]??'',$code);
       return $code;
@@ -711,7 +711,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
             }
             #if this is a consumers job use a different runtime cmd
             if (isset($jobconfig["consumers"]) && $jobconfig["consumers"]) {
-              $consumerName = str_replace("mm_consumer_","",$jobconfig["name"]);
+              $consumerName = str_replace("mm_consumer_","",(string)$jobconfig["name"]);
               if (!$this->canExecuteConsumer($consumerName)) {
                 continue;
               }
@@ -1094,7 +1094,7 @@ class Schedule extends \Magento\Framework\DataObject implements \Magento\Framewo
           }
 
           #If output had "error" in the text, assume it errored
-          if (strpos(strtolower($output),'error') > 0) {
+          if (strpos(strtolower((string)$output),'error') > 0) {
             $this->setJobStatus($scheduleid,'error',$output);
           } else {
             $this->setJobStatus($scheduleid,'success',$output);

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 # Cron
 #### This module for Magento 2 overrides base magento cron functionality, fixes known bugs, and provides a cron service model to control cron process execution. 
 
-![Version 1.3.5](https://img.shields.io/badge/Version-1.3.5-green.svg)
+![Version 1.3.7](https://img.shields.io/badge/Version-1.3.7-green.svg)
 
 NOTICE: Version 1.3x is only supported for Magento 2.3 and above. Older Magento 2 version use module version 1.2
 
-The default cron can overlap and fill the cron_schedule table, which can cause exponentially more jobs to run on each cron interval, until finally the crons run continously and never complete.  The high number of cron jobs can also crash servers hosting Magento 2. 
+The default cron can overlap and fill the cron_schedule table, which can cause exponentially more jobs to run on each cron interval, until finally the crons run continuously and never complete.  The high number of cron jobs can also crash servers hosting Magento 2. 
 
 This module replaces the cron management with a service that accepts jobs. As jobs are scheduled, they are picked up by this service for execution.  If a job is already running and another is picked up with the same job code, the new one is marked as missed.  Duplicate jobs are prevented from running, reducing server overhead.
 
@@ -19,7 +19,12 @@ In addition to the service model many other enhancements have been made.  For ex
 
 In version 1.1 Cron Reporting was added to the admin to show job code statistics and list cron run errors.
 
-In version 1.3 fixes are implemented for the consumers_runner cron job. This job code is a throwback from magento 1 and is more frequently used in Magento 2.3. It runs under its own scheduler which can execute many child jobs and bomb the system. In this version of the module this parent job is intercepted and written as individual jobs in the cron_schedule table and then run in a sane manner from there. These consumer jobs can also go into infinate loops, so a timeout is imposed on them by default of 30 seconds. This setting can be adjusted in the admin.
+In version 1.2.5 Cron execution will run if in maintenance mode with exempt IPs, allowing for full internal verification including necessary crons.
+
+In version 1.3 fixes are implemented for the consumers_runner cron job. This job code is a throwback from magento 1 and is more frequently used in Magento 2.3. It runs under its own scheduler which can execute many child jobs and bomb the system. In this version of the module this parent job is intercepted and written as individual jobs in the cron_schedule table and then run in a sane manner from there. These consumer jobs can also go into infinite loops, so a timeout is imposed on them by default of 30 seconds. This setting can be adjusted in the admin.
+
+In version 1.3.7 the consumers governor was added to terminate idle consumers jobs. Bugs in these jobs otherwise prevent these jobs from completing.
+
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -32,7 +37,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * Prevents cron history records from exploding.
 
-* Stops cron processes from overruning each other.
+* Stops cron processes from overrunning each other.
 
 * Stops the cron from running while system is under configurable load conditions.
 
@@ -51,6 +56,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 **Max Load Average** - Defined by the php function sys.getloadavg() / number of cpu cores. The function sys.getloadavg() is reported 1.0 for each core in use, just like the load average reported in top.  The number of cpu cores is pulled from /proc/cpuinfo and load average is divided by this number. Example: If you have 8 cores and you're using 6 then this is returned as 0.75. If your Max Load Average is 0.76 your crons will not run. Your load average falls to 0.74.  Your crons will run.  Any cron that was scheduled to run but didn't will be run.  If the same cron was missed multiple times, the most recent job will run, and the rest will be marked as missed. Default is 0.75 (75% of your available cpu).
 
 **History Retention** - The number of days history to keep in the cron_schedule table. Default 1 (1 day).
+
+**Consumers Job Timeout** - The number of seconds to allow a consumer job to run. These jobs can infinitely run under some conditions.
+
+**Exporters Job Timeout** - The number of seconds to allow the exportProcessor job to run. Default 3600 seconds.
+
+**Consumers Govenor:** - Many bugs in consumers processes cause them to run infinitely. The consumers governor will detect these states and terminate the processes.
 
 ## Composer Install
 

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -6,15 +6,16 @@ use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 
+use function version_compare;
+use function array_push;
+
 class UpgradeData implements UpgradeDataInterface
 {
 
 	public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
 	{
-		if (version_compare($context->getVersion(), '1.3.0', '<')) {
-			$connection = $setup->getConnection();
-
-
+        $connection = $setup->getConnection();
+        if (version_compare($context->getVersion(), '1.3.0', '<')) {
 			$select = $connection->select()->from($setup->getTable('core_config_data'))->where('path like ?', 'magemojo/cron/consumers_timeout');
 			$result = $connection->fetchAll($select);
 
@@ -25,5 +26,26 @@ class UpgradeData implements UpgradeDataInterface
 			  $connection->insertMultiple($setup->getTable('core_config_data'), $insertData);
             }
 		}
+        if (version_compare($context->getVersion(), '1.3.6', '<')) {
+
+            $select = $connection->select()->from($setup->getTable('core_config_data'))->where('path like ?', 'magemojo/cron/exporters_timeout');
+            $result = $connection->fetchAll($select);
+
+            #Create core_config_data settings
+            if (count($result) == 0) {
+                $insertData = array();
+                array_push($insertData,array('scope' => 'default', 'scope_id' => 0, 'path' => 'magemojo/cron/exporters_timeout', 'value' => '3600'));
+                $connection->insertMultiple($setup->getTable('core_config_data'), $insertData);
+            }
+            $select = $connection->select()->from($setup->getTable('core_config_data'))->where('path like ?', 'magemojo/cron/consumersgovernor');
+            $result = $connection->fetchAll($select);
+
+            #Create core_config_data settings
+            if (count($result) == 0) {
+                $insertData = array();
+                array_push($insertData,array('scope' => 'default', 'scope_id' => 0, 'path' => 'magemojo/cron/consumersgovernor', 'value' => '1'));
+                $connection->insertMultiple($setup->getTable('core_config_data'), $insertData);
+            }
+        }
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
     "require": {
         "php": ">=7.0.0"
     },
+    "suggest": {
+        "magento/module-cron": "*",
+        "magento/module-config": "*",
+        "magento/framework": "*",
+        "magento/module-store": "*"
+    },
     "autoload": {
       "files": [
         "registration.php"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,5 +29,17 @@
             <argument name="schedule" xsi:type="object">MageMojo\Cron\Model\Schedule\Proxy</argument>
         </arguments>
     </type>
+
+    <virtualType name="MageMojoCronConfig" type="Magento\Cron\Model\Config">
+        <arguments>
+            <argument name="configData" xsi:type="object">MageMojo\Cron\Model\Config\Data</argument>
+        </arguments>
+    </virtualType>
+    <type name="MageMojo\Cron\Model\Schedule">
+        <arguments>
+            <argument name="cronconfig" xsi:type="object">MageMojoCronConfig</argument>
+        </arguments>
+    </type>
+
 </config>
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MageMojo_Cron" setup_version="1.3.5">
+    <module name="MageMojo_Cron" setup_version="1.3.7">
         <sequence>
             <module name="Magento_Cron"/>
         </sequence>

--- a/view/adminhtml/templates/reports.phtml
+++ b/view/adminhtml/templates/reports.phtml
@@ -55,9 +55,9 @@ Execution times are in: <?= $timezone ?>
       $executed = $job["executed_at"];
       $runtime = '';
     } else {
-      $executed = strtotime($job["executed_at"]);
+      $executed = strtotime((string)$job["executed_at"]);
       $executed = date("Y-m-d h:i:s A",($executed - $timediff));
-      $runtime = strtotime($job["finished_at"]) - strtotime($job["executed_at"]) .'s';
+      $runtime = strtotime((string)$job["finished_at"]) - strtotime((string)$job["executed_at"]) .'s';
     }
     ?>
     <tr>

--- a/view/adminhtml/templates/settings.phtml
+++ b/view/adminhtml/templates/settings.phtml
@@ -9,47 +9,58 @@
 <div class="entry-edit form-inline">
     <div class="section-config">
       <table cellspacing="0" class="form-list"><colgroup class="label" /><colgroup class="value" /><colgroup class="scope-label" /><colgroup class="" /><tbody>
-        <tr id="row_general_country_default">
+        <tr id="row_cron_enabled">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Cron Enabled:</b></span></label></td>
           <td class="value" align="left"><?php $block->checkbox('magemojo/cron/enabled','enabled'); ?></td>
         </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">Turn the cron on/off.</td>
         </tr>
-        <tr id="row_general_country_default">
+        <tr id="row_max_processes">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Maximum Cron Processes:</b></span></label></td>
           <td class="value" align="left"><?php $block->textfield('magemojo/cron/jobs','maxjobs',2,2); ?></td>
         </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">The number of cron threads running in parallel. This option is the sum of all defined jobs. Example: If you have 5 jobs set to run at midnight, Maximum Cron Processes set to 1, only 1 job will execute sequentially until all 5 are completed. Default 3.</td>
         </tr>
-        <tr id="row_general_country_default">
+        <tr id="row_php_binary">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>PHP Binary Name / Path:</b></span></label></td>
           <td class="value" align="left"><?php $block->textfield('magemojo/cron/phpproc','phpproc',10,100); ?></td>
         </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">The name of your php binary you run from the shell. Usually php or php70. You can optionally include the full path to the binary. Default php.</td>
         </tr>
-        <tr id="row_general_country_default">
+        <tr id="row_max_load">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Max Load Average:</b></span></label></td>
           <td class="value" align="left"><?php $block->textfield('magemojo/cron/maxload','maxload',2,2); ?></td>
         </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">Defined by the php function sys.getloadavg() / number of cpu cores. The function sys.getloadavg() is reported 1.0 for each core in use, just like the load average reported in top. The number of cpu cores is pulled from /proc/cpuinfo and load average is divided by this number. If load average exceeds this amount cron processes will be temporarily suspended until load decreases.</td>
         </tr>
-        <tr id="row_general_country_default">
+        <tr id="row_history_retention">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>History Retention:</b></span></label></td>
           <td class="value" align="left"><?php $block->textfield('magemojo/cron/history','history',4,4); ?></td>
         </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">The number of days history to keep in the cron_schedule table. Default 1 (1 day).</td>
         </tr>
-        <tr id="row_general_country_default">
+        <tr id="row_consumers_timeout">
           <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Consumers Job Timeout:</b></span></label></td>
           <td class="value" align="left"><?php $block->textfield('magemojo/cron/consumers_timeout','consumers_timeout',4,4); ?></td>
         </tr>
+        <tr id="row_exporters_timeout">
+          <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Exporters Job Timeout:</b></span></label></td>
+          <td class="value" align="left"><?php $block->textfield('magemojo/cron/exporters_timeout','exporters_timeout',4,4); ?></td>
+        </tr>
         <tr>
         <td colspan="2" style="padding-bottom: 10px;">The number of seconds to allow a consumers job to run. These jobs can infinitely run under some conditions.</td>
+        </tr>
+        <tr id="row_consumers_governor">
+          <td class="label" width="250"><span data-config-scope="[STORE VIEW]"><b>Consumers Governor:</b></span></label></td>
+          <td class="value" align="left"><?php $block->checkbox('magemojo/cron/consumersgovernor','consumersgovernor'); ?></td>
+        </tr>
+        <tr>
+            <td colspan="2" style="padding-bottom: 10px;">Many bugs in consumers processes cause them to run indefinately. The consumers governor will detect these states and terminate the processes.</td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
- Fixed:
    + Fix compability issues (cherry picked from commit https://github.com/Amakata/m2-ce-cron/commit/7aa4f1ca1b6c38c451fc10f3b1c43b08ecfa3044).
    + Error `Return value of "MageMojo\Cron\Console\Command\CronCommand::execute()" must be of the type int, "null" returned`.